### PR TITLE
Add optional 'MAGICC_EXECUTABLE' environment parameter

### DIFF
--- a/pymagicc/__init__.py
+++ b/pymagicc/__init__.py
@@ -29,13 +29,20 @@ __version__ = get_versions()["version"]
 del get_versions
 
 
+def get_paths():
+    default_executable = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "MAGICC6/MAGICC6_4Download/magicc6.exe"
+    )
+    
+    executable = os.environ.get('MAGICC_EXECUTABLE', default_executable)
+    return os.path.dirname(executable), os.path.basename(executable)
+
+
+_magiccpath, _magiccbinary = get_paths()
+
 _WINDOWS = platform.system() == "Windows"
 
-_magiccpath = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    "MAGICC6/MAGICC6_4Download"
-)
-_magiccbinary = "magicc6.exe"
 
 if not _WINDOWS:
     wine_installed = subprocess.call("type wine", shell=True,

--- a/tests/test_pymagicc.py
+++ b/tests/test_pymagicc.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from pymagicc import (
     _magiccpath,
+    get_paths,
     _get_number_of_datapoints,
     _get_region_code,
     read_scen_file,
@@ -145,3 +146,13 @@ def test_set_years():
     assert conf["years"]["endyear"] == 2000
     assert results["SURFACE_TEMP"].GLOBAL.index[0] == 1900
     assert results["SURFACE_TEMP"].GLOBAL.index[-1] == 2000
+
+
+def test_custom_magicc():
+    os.environ['MAGICC_EXECUTABLE'] = '/tmp/magicc'
+    path, binary = get_paths()
+    # reset the key
+    del os.environ['MAGICC_EXECUTABLE']
+
+    assert path == '/tmp'
+    assert binary == 'magicc'


### PR DESCRIPTION
If environment variable 'MAGICC_EXECUTABLE' is set, this binary is used run instead of the included version of magicc.