### PR TITLE
[WIP] Stop supporting Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: trusty
 sudo: required
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ],


### PR DESCRIPTION
If needed it could fairly easily be supported again,
but not doing so speeds up CI and simplifies some edge
cases. New libraries like `pathlib` can also be used
directly.