### PR TITLE
Rename MAGICC baseclass to MAGICCBase and expose MAGICC6 as MAGICC

### DIFF
--- a/pymagicc/__init__.py
+++ b/pymagicc/__init__.py
@@ -26,6 +26,9 @@ from .api import MAGICC6, MAGICC7  # noqa
 __version__ = get_versions()["version"]
 del get_versions
 
+# Default to using MAGICC6 for now
+MAGICC = MAGICC6
+
 # default parameters and cannot be changed after module load
 _magiccpath, _magiccbinary = MAGICC6().original_dir, MAGICC6().original_dir
 

--- a/pymagicc/api.py
+++ b/pymagicc/api.py
@@ -27,7 +27,7 @@ def _copy_files(source, target):
             shutil.copy(full_filename, target)
 
 
-class MAGICC(object):
+class MAGICCBase(object):
     """
     Provides access to the MAGICC binary and configuration.
 
@@ -213,14 +213,14 @@ class MAGICC(object):
                                stepsperyear=12)
 
 
-class MAGICC6(MAGICC):
+class MAGICC6(MAGICCBase):
     version = 6
 
     def get_executable(cls):
         return config['executable']
 
 
-class MAGICC7(MAGICC):
+class MAGICC7(MAGICCBase):
     version = 7
 
     def get_executable(cls):


### PR DESCRIPTION
I won't die in a ditch whether or not to expose a MAGICC class (which defaults to MAGICC6) as the default implementation of the API.

Either way, MAGICCBase is a better name as it is an abstract base class and cannot be directly instantiated.