### PR TITLE
Exception on missing executable

### DIFF
--- a/pymagicc/api.py
+++ b/pymagicc/api.py
@@ -80,11 +80,16 @@ class MAGICCBase(object):
     def __exit__(self, *args, **kwargs):
         self.remove_temp_copy()
 
+    def get_executable(self):
+        raise NotImplementedError
+
     def create_copy(self):
         """
         Initialises a temporary directory structure and copy of MAGICC
         configuration files and binary.
         """
+        if self.executable is None or not isfile(self.executable):
+            raise FileNotFoundError('Could not find MAGICC{} executable: {}'.format(self.version, self.executable))
         if self.is_temp:
             assert (
                 self.root_dir is None
@@ -196,7 +201,7 @@ class MAGICCBase(object):
         """
         Removes a temporary copy of the MAGICC version shipped with Pymagicc.
         """
-        if self.is_temp:
+        if self.is_temp and self.root_dir is not None:
             shutil.rmtree(self.root_dir)
             self.root_dir = None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import pandas as pd
 import f90nml
 
 from pymagicc.api import MAGICCBase, MAGICC6, MAGICC7, config, _clean_value
-
+from .test_config import config_override #  noqa
 
 @pytest.fixture(scope="module")
 def magicc_base():
@@ -135,7 +135,7 @@ def test_incorrect_subdir():
     config["EXECUTABLE_6"] = "/tmp/magicc"
     magicc = MAGICC6()
     try:
-        with pytest.raises(AssertionError):
+        with pytest.raises(FileNotFoundError):
             magicc.create_copy()
     finally:
         del config.overrides["EXECUTABLE_6"]
@@ -369,3 +369,22 @@ def test_integration_diagnose_tcr_ecs(package):
         assert (
             actual_result["ecs"] == 2.9968448
         )  # MAGICC6 shipped with pymagicc should be stable
+
+
+def test_missing_config(config_override):
+    with MAGICC6():
+        pass
+    config_override("EXECUTABLE_6", "")
+    with pytest.raises(FileNotFoundError):
+        with MAGICC6():
+            pass
+
+    config_override("EXECUTABLE_6", "/invalid/path")
+    with pytest.raises(FileNotFoundError):
+        with MAGICC6():
+            pass
+
+    config_override("EXECUTABLE_7", "")
+    with pytest.raises(FileNotFoundError):
+        with MAGICC7():
+            pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,23 +10,49 @@ from pymagicc.config import (
 )
 
 
-@pytest.fixture(scope="function")
-def env_var():
-    # Set environment variables for the duration of the test
+def temp_set_var(store):
+    """
+    Temporary sets a value of a Dict-like object for the duration of a test
+    :param store: A Dict-like object which holds key-value pairs. The store is
+        restored to its original state at the end of the test
+    """
     prev_values = {}
 
-    def set_env_var(name, value):
-        prev_values[name] = environ.get(name)
-        environ[name] = value
-
-    yield set_env_var
-
-    # Clean up any set env variables
-    for n in prev_values:
-        if prev_values[n] is not None:
-            environ[n] = prev_values[n]
+    def set_var(name, value):
+        if name not in prev_values:  # Only remember the first value
+            prev_values[name] = store.get(name)
+        if value is None:
+            try:
+                del store[name]
+            except KeyError:
+                pass
         else:
-            del environ[n]
+            store[name] = value
+
+    def cleanup():
+        # Clean up any set variables
+        for n in prev_values:
+            if prev_values[n] is not None:
+                store[n] = prev_values[n]
+            else:
+                del store[n]
+
+    return set_var, cleanup
+
+
+
+@pytest.fixture(scope="function")
+def env_override():
+    set_var, cleanup = temp_set_var(environ)
+    yield set_var
+    cleanup()
+
+
+@pytest.fixture(scope="function")
+def config_override():
+    set_var, cleanup = temp_set_var(config.overrides)
+    yield set_var
+    cleanup()
 
 
 def test_lookup_default():
@@ -35,13 +61,13 @@ def test_lookup_default():
     assert lookup_defaults("SOMETHING") is None
 
 
-def test_lookup_env(env_var):
-    env_var("MAGICC_EXECUTABLE_6", "/foo/bar/magicc")
+def test_lookup_env(env_override):
+    env_override("MAGICC_EXECUTABLE_6", "/foo/bar/magicc")
     assert lookup_env("EXECUTABLE_6") == "/foo/bar/magicc"
     assert lookup_env("executable_6") == "/foo/bar/magicc"
 
     assert lookup_env("OTHER") is None
-    env_var("MAGICC_OTHER", "test")
+    env_override("MAGICC_OTHER", "test")
     assert lookup_env("OTHER") == "test"
 
     # Something that isn't specified
@@ -52,11 +78,11 @@ def test_simple_config():
     assert config["EXECUTABLE_6"] == default_config["EXECUTABLE_6"]
 
 
-def test_precendence(env_var):
+def test_precendence(env_override):
     c = ConfigStore()
     assert c["EXECUTABLE_6"] == default_config["EXECUTABLE_6"]
 
-    env_var("MAGICC_EXECUTABLE_6", "/foo/bar/magicc")
+    env_override("MAGICC_EXECUTABLE_6", "/foo/bar/magicc")
     assert c["EXECUTABLE_6"] == "/foo/bar/magicc"
 
     c["executable_6"] = "testing"


### PR DESCRIPTION
The current failure mode if MAGICC6/MAGICC7 is misconfigured is very opaque. It raises an exception when a call to `os.path.exist` gets a `None`. 

This adds an explicit check when `create_copy` is called and raises a sane exception. 2 lines of code change 80 lines of tests!