### PR TITLE
WIP: Add AR5 TCR diagnosis definition

### DIFF
--- a/notebooks/Diagnose-TCR-ECS.ipynb
+++ b/notebooks/Diagnose-TCR-ECS.ipynb
@@ -4,7 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Diagnosing MAGICC's TCR and ECS"
+    "# Diagnosing MAGICC's TCR and ECS\n",
+    "\n",
+    "The equilibrium climate sensitivity (ECS) is defined as the equilibrium temperature response of the climate system to a doubling of atmospheric CO$_2$ concentrations from pre-industrial levels.\n",
+    "\n",
+    "There can be a little bit of confusion about the definition of the transient climate response (TCR). In particular, in the [Third Assessment Report (TAR)](https://www.ipcc.ch/ipccreports/tar/wg1/345.htm), TCR is defined as\n",
+    "\n",
+    "> the global mean temperature change which occurs at the time of CO$_2$ doubling for the specific case of a 1%/yr increase of CO2 is termed the transient climate response (TCR) of the system.\n",
+    "\n",
+    "However, in the [Fifth Assessment Report (AR5)](http://www.climatechange2013.org/images/report/WG1AR5_Chapter09_FINAL.pdf), TCR is defined as \n",
+    "\n",
+    "> The transient climate response (TCR) is the change in global and annual\n",
+    "mean surface temperature from an experiment in which the CO$_2$ concentration is increased by 1% yr$^{–1}$, and calculated using the difference between the start of the experiment and a 20-year period centred on the time of CO$_2$ doubling.\n",
+    "\n",
+    "Because it seems like the more common and appropriate definition for a simple climate model like MAGICC (which has no internal variability), and for simplicity's sake, we choose to use the definition used in the TAR. "
    ]
   },
   {
@@ -115,7 +128,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
- [ ]  add `TCR_def` switch to `diagnose_ecs_tcr` to allow users to easily compare the effect of using different definitions should they so wish