### PR TITLE
Make CI more verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - pip install -e .
 script:
-  - pytest --cov
+  - pytest --cov -rfsxEX
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then ./scripts/test_notebooks.sh; fi
 after_success:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: venv
 
 test: venv
 	@[ ! -z "`which wine`" ] || echo 'If you want to test pymagicc fully on a non-windows system, install wine now'
-	./venv/bin/pytest tests
+	./venv/bin/pytest -rfsxEX tests
 
 test-notebooks: venv notebooks/*.ipynb
 	./scripts/test_notebooks.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,5 +15,5 @@ install:
   - "%PYTHON%/Scripts/pip.exe install ."
 
 test_script:
-  - "%PYTHON%/Scripts/pytest tests"
+  - "%PYTHON%/Scripts/pytest -rfsxEX tests"
 


### PR DESCRIPTION
Please confirm that this pull request has done the following:

- [ ] Rebased

Makes reasons tests are skipped and expected to fail clearer, useful for debugging CI e.g. output goes from

```sh
$ pytest
============================= test session starts ==============================
platform darwin -- Python 3.6.5, pytest-3.8.0, py-1.6.0, pluggy-0.7.1
rootdir: /Users/zebedeenicholls/Documents/AGCEC/MCastle/pymagicc, inifile: setup.cfg
plugins: cov-2.6.0, nbval-0.9.1
collected 212 items                                                            

tests/test_api.py ......sssss..............                              [ 11%]
tests/test_config.py .....                                               [ 14%]
tests/test_io.py .....................x................................. [ 40%]
........................................................................ [ 74%]
.........................................                                [ 93%]
tests/test_pymagicc.py ..............                                    [100%]

============== 206 passed, 5 skipped, 1 xfailed in 33.10 seconds ===============
```

to

```sh
$ pytest -rfsxEX
=============================== test session starts ================================
platform darwin -- Python 3.6.5, pytest-3.8.0, py-1.6.0, pluggy-0.7.1
rootdir: /Users/zebedeenicholls/Documents/AGCEC/MCastle/pymagicc, inifile: setup.cfg
plugins: cov-2.6.0, nbval-0.9.1
collected 212 items                                                                

tests/test_api.py ......sssss..............                                  [ 11%]
tests/test_config.py .....                                                   [ 14%]
tests/test_io.py ...............................x........................... [ 41%]
............................................................................ [ 77%]
.................................                                            [ 93%]
tests/test_pymagicc.py ..............                                        [100%]
============================= short test summary info ==============================
SKIP [5] /Users/zebedeenicholls/Documents/AGCEC/MCastle/pymagicc/tests/test_api.py:27: MAGICC 7 is not available
XFAIL tests/test_io.py::test_load_cfg_with_slash_in_units
  f90nml cannot handle '/' in namelist properly

================ 206 passed, 5 skipped, 1 xfailed in 36.54 seconds =================
```