### PR TITLE
Minimise output

### DIFF
--- a/pymagicc/api.py
+++ b/pymagicc/api.py
@@ -324,6 +324,91 @@ class MAGICCBase(object):
             stepsperyear=12,
         )
 
+    def set_output_variables(self, write_ascii=True, write_binary=False, **kwargs):
+        """
+        Writes the configuration to control what variables are written
+
+        # Parameters
+        write_binary (bool): If true, MAGICC is configured to write output files as human readable ascii files.
+        write_ascii (bool): If true, MAGICC is configured to write binary output files. These files are much faster
+            to process, but are not human readable.
+        kwargs: List of variables to write out. A list of possible options are as follows. This
+         may not be a complete list
+
+            'emissions',
+            'gwpemissions',
+            'sum_gwpemissions',
+            'concentrations',
+            'carboncycle',
+            'forcing',
+            'surfaceforcing',
+            'permafrost',
+            'temperature',
+            'sealevel',
+            'parameters',
+            'misc',
+            'lifetimes',
+            'timeseriesmix',
+            'rcpdata',
+            'summaryidx',
+            'inverseemis',
+            'tempoceanlayers',
+            'oceanarea',
+            'heatuptake',
+            'warnings',
+            'precipinput',
+            'aogcmtuning',
+            'ccycletuning',
+            'observationaltuning',
+            'keydata_1',
+            'keydata_2'
+        """
+
+        assert write_ascii or write_binary, 'write_binary and/or write_ascii must be configured'
+        if write_binary and write_ascii:
+            ascii_binary = 'BOTH'
+        elif write_ascii:
+            ascii_binary = 'ASCII'
+        else:
+            ascii_binary = 'BINARY'
+
+        # defaults
+        outconfig = {
+            'out_emissions': 0,
+            'out_gwpemissions': 0,
+            'out_sum_gwpemissions': 0,
+            'out_concentrations': 0,
+            'out_carboncycle': 0,
+            'out_forcing': 0,
+            'out_surfaceforcing': 0,
+            'out_permafrost': 0,
+            'out_temperature': 0,
+            'out_sealevel': 0,
+            'out_parameters': 0,
+            'out_misc': 0,
+            'out_lifetimes': 0,
+            'out_timeseriesmix': 0,
+            'out_rcpdata': 0,
+            'out_summaryidx': 0,
+            'out_inverseemis': 0,
+            'out_tempoceanlayers': 0,
+            'out_oceanarea': 0,
+            'out_heatuptake': 0,
+            'out_ascii_binary': ascii_binary,
+            'out_warnings': 0,
+            'out_precipinput': 0,
+            'out_aogcmtuning': 0,
+            'out_ccycletuning': 0,
+            'out_observationaltuning': 0,
+            'out_keydata_1': 0,
+            'out_keydata_2': 0,
+        }
+        for kw in kwargs:
+            val = 1 if kwargs[kw] else 0  # convert values to 0/1 instead of booleans
+            outconfig['out_' + kw.lower()] = val
+
+        self.update_config(**outconfig)
+
     def get_executable(self):
         return config["executable_{}".format(self.version)]
 

--- a/pymagicc/api.py
+++ b/pymagicc/api.py
@@ -270,6 +270,35 @@ class MAGICCBase(object):
 
         return data
 
+    def update_config(
+        self, filename="MAGTUNE_PYMAGICC.CFG", top_level_key="nml_allcfgs", **kwargs
+        ):
+        """
+        Updates a configuration file for MAGICC
+
+        Updates the contents of a fortran namelist in the run directory, creating a new namelist if none exists.
+
+        # Parameters
+        filename (str): Name of configuration file to write
+        top_level_key (str): Name of namelist to be written in the
+            configuration file
+        kwargs: Other parameters to pass to the configuration file. No
+            validation on the parameters is performed.
+
+        # Returns
+        data (dict): The contents of the namelist which was written to file
+        """
+        fname = join(self.run_dir, filename)
+
+        if exists(fname):
+            conf = f90nml.read(fname)
+        else:
+            conf = {top_level_key: {}}
+        conf[top_level_key].update(kwargs)
+        f90nml.write(conf, fname, force=True)
+
+        return conf
+
     def set_years(self, startyear=1765, endyear=2100):
         """
         Set the start and end dates of the simulations.

--- a/pymagicc/api.py
+++ b/pymagicc/api.py
@@ -272,7 +272,7 @@ class MAGICCBase(object):
 
     def update_config(
         self, filename="MAGTUNE_PYMAGICC.CFG", top_level_key="nml_allcfgs", **kwargs
-        ):
+    ):
         """
         Updates a configuration file for MAGICC
 
@@ -364,48 +364,50 @@ class MAGICCBase(object):
             'keydata_2'
         """
 
-        assert write_ascii or write_binary, 'write_binary and/or write_ascii must be configured'
+        assert (
+            write_ascii or write_binary
+        ), "write_binary and/or write_ascii must be configured"
         if write_binary and write_ascii:
-            ascii_binary = 'BOTH'
+            ascii_binary = "BOTH"
         elif write_ascii:
-            ascii_binary = 'ASCII'
+            ascii_binary = "ASCII"
         else:
-            ascii_binary = 'BINARY'
+            ascii_binary = "BINARY"
 
         # defaults
         outconfig = {
-            'out_emissions': 0,
-            'out_gwpemissions': 0,
-            'out_sum_gwpemissions': 0,
-            'out_concentrations': 0,
-            'out_carboncycle': 0,
-            'out_forcing': 0,
-            'out_surfaceforcing': 0,
-            'out_permafrost': 0,
-            'out_temperature': 0,
-            'out_sealevel': 0,
-            'out_parameters': 0,
-            'out_misc': 0,
-            'out_lifetimes': 0,
-            'out_timeseriesmix': 0,
-            'out_rcpdata': 0,
-            'out_summaryidx': 0,
-            'out_inverseemis': 0,
-            'out_tempoceanlayers': 0,
-            'out_oceanarea': 0,
-            'out_heatuptake': 0,
-            'out_ascii_binary': ascii_binary,
-            'out_warnings': 0,
-            'out_precipinput': 0,
-            'out_aogcmtuning': 0,
-            'out_ccycletuning': 0,
-            'out_observationaltuning': 0,
-            'out_keydata_1': 0,
-            'out_keydata_2': 0,
+            "out_emissions": 0,
+            "out_gwpemissions": 0,
+            "out_sum_gwpemissions": 0,
+            "out_concentrations": 0,
+            "out_carboncycle": 0,
+            "out_forcing": 0,
+            "out_surfaceforcing": 0,
+            "out_permafrost": 0,
+            "out_temperature": 0,
+            "out_sealevel": 0,
+            "out_parameters": 0,
+            "out_misc": 0,
+            "out_lifetimes": 0,
+            "out_timeseriesmix": 0,
+            "out_rcpdata": 0,
+            "out_summaryidx": 0,
+            "out_inverseemis": 0,
+            "out_tempoceanlayers": 0,
+            "out_oceanarea": 0,
+            "out_heatuptake": 0,
+            "out_ascii_binary": ascii_binary,
+            "out_warnings": 0,
+            "out_precipinput": 0,
+            "out_aogcmtuning": 0,
+            "out_ccycletuning": 0,
+            "out_observationaltuning": 0,
+            "out_keydata_1": 0,
+            "out_keydata_2": 0,
         }
         for kw in kwargs:
             val = 1 if kwargs[kw] else 0  # convert values to 0/1 instead of booleans
-            outconfig['out_' + kw.lower()] = val
+            outconfig["out_" + kw.lower()] = val
 
         self.update_config(**outconfig)
 

--- a/pymagicc/api.py
+++ b/pymagicc/api.py
@@ -273,20 +273,25 @@ class MAGICCBase(object):
     def update_config(
         self, filename="MAGTUNE_PYMAGICC.CFG", top_level_key="nml_allcfgs", **kwargs
     ):
-        """
-        Updates a configuration file for MAGICC
+        """Updates a configuration file for MAGICC
 
-        Updates the contents of a fortran namelist in the run directory, creating a new namelist if none exists.
+        Updates the contents of a fortran namelist in the run directory,
+        creating a new namelist if none exists.
 
-        # Parameters
-        filename (str): Name of configuration file to write
-        top_level_key (str): Name of namelist to be written in the
+        Parameters
+        ----------
+        filename : str
+            Name of configuration file to write
+        top_level_key : str
+            Name of namelist to be written in the
             configuration file
-        kwargs: Other parameters to pass to the configuration file. No
+        kwargs
+            Other parameters to pass to the configuration file. No
             validation on the parameters is performed.
-
-        # Returns
-        data (dict): The contents of the namelist which was written to file
+        Returns
+        -------
+        dict
+            The contents of the namelist which was written to file
         """
         fname = join(self.run_dir, filename)
 
@@ -325,15 +330,23 @@ class MAGICCBase(object):
         )
 
     def set_output_variables(self, write_ascii=True, write_binary=False, **kwargs):
-        """
-        Writes the configuration to control what variables are written
+        """Writes the output configuration
 
-        # Parameters
-        write_binary (bool): If true, MAGICC is configured to write output files as human readable ascii files.
-        write_ascii (bool): If true, MAGICC is configured to write binary output files. These files are much faster
-            to process, but are not human readable.
-        kwargs: List of variables to write out. A list of possible options are as follows. This
-         may not be a complete list
+        There are a number of configuration parameters which control which variables are written to
+        file and in which format. Limiting the variables that are written to file can greatly speed
+        up the running of MAGICC. By default, calling this function without specifying any variables
+        will disable all output.
+
+        Parameters
+        ----------
+        write_ascii : bool
+            If true, MAGICC is configured to write output files as human readable ascii files.
+        write_binary : bool
+            If true, MAGICC is configured to write binary output files. These files are much faster
+            to process and write, but are not human readable.
+        kwargs:
+            List of variables to write out. A list of possible options are as follows. This
+            may not be a complete list.
 
             'emissions',
             'gwpemissions',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -599,3 +599,27 @@ def test_read_parameters():
         magicc.run()
         assert isinstance(magicc.config, dict)
         assert "allcfgs" in magicc.config
+
+
+def test_updates_namelist(package):
+    write_config(package)
+
+    fname = join(package.run_dir, "MAGTUNE_SIMPLE.CFG")
+    raw_conf = f90nml.read(fname)
+    assert 'test_value' not in raw_conf['nml_allcfgs']
+
+    package.update_config('MAGTUNE_SIMPLE.CFG', test_value=1.2)
+
+    updated_conf = f90nml.read(fname)
+    assert 'test_value' in updated_conf['nml_allcfgs']
+
+
+def test_updates_namelist_missing(package):
+    fname = join(package.run_dir, "MAGTUNE_NOTEXISTS.CFG")
+
+    assert not exists(fname)
+
+    package.update_config('MAGTUNE_NOTEXISTS.CFG', test_value=1.2)
+
+    updated_conf = f90nml.read(fname)
+    assert 'test_value' in updated_conf['nml_allcfgs']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -623,3 +623,39 @@ def test_updates_namelist_missing(package):
 
     updated_conf = f90nml.read(fname)
     assert 'test_value' in updated_conf['nml_allcfgs']
+
+
+def test_ascii_output(package):
+    fname = join(package.run_dir, "MAGTUNE_PYMAGICC.CFG")
+
+    package.set_output_variables(write_ascii=True, write_binary=True)
+    raw_conf = f90nml.read(fname)
+    assert raw_conf['nml_allcfgs']['OUT_ASCII_BINARY'] == 'BOTH'
+
+    package.set_output_variables(write_ascii=False, write_binary=True)
+    raw_conf = f90nml.read(fname)
+    assert raw_conf['nml_allcfgs']['OUT_ASCII_BINARY'] == 'BINARY'
+
+    package.set_output_variables()
+    raw_conf = f90nml.read(fname)
+    assert raw_conf['nml_allcfgs']['OUT_ASCII_BINARY'] == 'ASCII'
+
+    with pytest.raises(AssertionError):
+        package.set_output_variables(write_ascii=False, write_binary=False)
+
+
+def test_output_variables(package):
+    fname = join(package.run_dir, "MAGTUNE_PYMAGICC.CFG")
+
+    package.set_output_variables()
+    raw_conf = f90nml.read(fname)
+    assert raw_conf['nml_allcfgs']['OUT_TEMPERATURE'] == 0
+
+    package.set_output_variables(temperature=True)
+    raw_conf = f90nml.read(fname)
+    assert raw_conf['nml_allcfgs']['OUT_TEMPERATURE'] == 1
+
+    # Even accepts invalid variable names
+    package.set_output_variables(this_doesnt_exist=False)
+    raw_conf = f90nml.read(fname)
+    assert raw_conf['nml_allcfgs']['OUT_THIS_DOESNT_EXIST'] == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -606,12 +606,12 @@ def test_updates_namelist(package):
 
     fname = join(package.run_dir, "MAGTUNE_SIMPLE.CFG")
     raw_conf = f90nml.read(fname)
-    assert 'test_value' not in raw_conf['nml_allcfgs']
+    assert "test_value" not in raw_conf["nml_allcfgs"]
 
-    package.update_config('MAGTUNE_SIMPLE.CFG', test_value=1.2)
+    package.update_config("MAGTUNE_SIMPLE.CFG", test_value=1.2)
 
     updated_conf = f90nml.read(fname)
-    assert 'test_value' in updated_conf['nml_allcfgs']
+    assert "test_value" in updated_conf["nml_allcfgs"]
 
 
 def test_updates_namelist_missing(package):
@@ -619,10 +619,10 @@ def test_updates_namelist_missing(package):
 
     assert not exists(fname)
 
-    package.update_config('MAGTUNE_NOTEXISTS.CFG', test_value=1.2)
+    package.update_config("MAGTUNE_NOTEXISTS.CFG", test_value=1.2)
 
     updated_conf = f90nml.read(fname)
-    assert 'test_value' in updated_conf['nml_allcfgs']
+    assert "test_value" in updated_conf["nml_allcfgs"]
 
 
 def test_ascii_output(package):
@@ -630,15 +630,15 @@ def test_ascii_output(package):
 
     package.set_output_variables(write_ascii=True, write_binary=True)
     raw_conf = f90nml.read(fname)
-    assert raw_conf['nml_allcfgs']['OUT_ASCII_BINARY'] == 'BOTH'
+    assert raw_conf["nml_allcfgs"]["OUT_ASCII_BINARY"] == "BOTH"
 
     package.set_output_variables(write_ascii=False, write_binary=True)
     raw_conf = f90nml.read(fname)
-    assert raw_conf['nml_allcfgs']['OUT_ASCII_BINARY'] == 'BINARY'
+    assert raw_conf["nml_allcfgs"]["OUT_ASCII_BINARY"] == "BINARY"
 
     package.set_output_variables()
     raw_conf = f90nml.read(fname)
-    assert raw_conf['nml_allcfgs']['OUT_ASCII_BINARY'] == 'ASCII'
+    assert raw_conf["nml_allcfgs"]["OUT_ASCII_BINARY"] == "ASCII"
 
     with pytest.raises(AssertionError):
         package.set_output_variables(write_ascii=False, write_binary=False)
@@ -649,13 +649,13 @@ def test_output_variables(package):
 
     package.set_output_variables()
     raw_conf = f90nml.read(fname)
-    assert raw_conf['nml_allcfgs']['OUT_TEMPERATURE'] == 0
+    assert raw_conf["nml_allcfgs"]["OUT_TEMPERATURE"] == 0
 
     package.set_output_variables(temperature=True)
     raw_conf = f90nml.read(fname)
-    assert raw_conf['nml_allcfgs']['OUT_TEMPERATURE'] == 1
+    assert raw_conf["nml_allcfgs"]["OUT_TEMPERATURE"] == 1
 
     # Even accepts invalid variable names
     package.set_output_variables(this_doesnt_exist=False)
     raw_conf = f90nml.read(fname)
-    assert raw_conf['nml_allcfgs']['OUT_THIS_DOESNT_EXIST'] == 0
+    assert raw_conf["nml_allcfgs"]["OUT_THIS_DOESNT_EXIST"] == 0


### PR DESCRIPTION
Adds the `update_config` and `set_output_variables` functions to `MAGICCBase`. This isn't a fully automatic solution, but rather more of a helper routine. Determining the outputs to turn on from a variable name might be a bit flaky. 

#113 