### PR TITLE
Make test-pypi-install also test imports of all dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-testpypi-install: venv
 		-i https://testpypi.python.org/pypi pymagicc \
 		--no-dependencies --pre
 	# Remove local directory from path to get actual installed version.
+	@echo "This doesn't test dependencies"
 	$(TEMPVENV)/bin/python -c "import sys; sys.path.remove(''); import pymagicc; print(pymagicc.__version__)"
 
 publish-on-pypi: venv
@@ -63,7 +64,7 @@ test-pypi-install: venv
 	python3 -m venv $(TEMPVENV)
 	$(TEMPVENV)/bin/pip install pip --upgrade
 	$(TEMPVENV)/bin/pip install pymagicc --pre
-	$(TEMPVENV)/bin/python -c "import sys; sys.path.remove(''); import pymagicc; print(pymagicc.__version__)"
+	$(TEMPVENV)/bin/python scripts/test_install.py
 
 docs: docs/*.rst $(shell find ./pymagicc/ -type f -name '*.py') venv
 	./venv/bin/sphinx-build -M html docs docs/build

--- a/scripts/test_install.py
+++ b/scripts/test_install.py
@@ -1,0 +1,23 @@
+"""Test that all of our modules can be imported
+
+Thanks https://stackoverflow.com/a/25562415/10473080
+"""
+import importlib
+import pkgutil
+
+
+import pymagicc
+
+
+def import_submodules(package_name):
+    package = importlib.import_module(package_name)
+
+    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__):
+        full_name = package.__name__ + "." + name
+        importlib.import_module(full_name)
+        if is_pkg:
+            import_submodules(full_name)
+
+
+import_submodules("pymagicc")
+print(pymagicc.__version__)


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added (N/A)
- [x] Documentation added (N/A)
- [x] Example added (N/A)
- [x] Description in ``CHANGELOG.rst`` added (N/A)

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <http://link-to-pr.com>`_) Added feature which does something
- (`#XX <http://link-to-pr.com>`_) Fixed bug identified in (`#XX <http://link-to-issue.com>`_)
```

Just makes sure that when we import pymagicc, we go through and import all the dependencies in submodules too to double check that all the dependencies are importable (i.e. installed correctly)