### PR TITLE
remove trailing / in MANIFEST which is invalid syntax

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,9 +12,9 @@ recursive-include pymagicc/MAGICC6 *.txt
 
 include pymagicc/MAGICC6/out/.gitkeep
 
-recursive-include pymagicc/ *.csv
-recursive-include pymagicc/ *.DAT
-recursive-include pymagicc/ *.json
+recursive-include pymagicc *.csv
+recursive-include pymagicc *.DAT
+recursive-include pymagicc *.json
 
 include versioneer.py
 include pymagicc/_version.py


### PR DESCRIPTION
Fairly straightforward. Interesting though that it ignores the trailing / under linux, but not windows