### PR TITLE
Tweak permafrost read

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#227 <https://github.com/openclimatedata/pymagicc/pull/227>`_) Fixed up permafrost naming to avoid confusing inclusion when summing up "Emissions|CO2"
 - (`#226 <https://github.com/openclimatedata/pymagicc/pull/226>`_) Add ``SURFACE_TEMP.IN`` writer, closing `#211 <https://github.com/openclimatedata/pymagicc/issues/211>`_
 - (`#225 <https://github.com/openclimatedata/pymagicc/pull/225>`_) Fix reading of ``DAT_CO2PF_EMIS.OUT``
 - (`#224 <https://github.com/openclimatedata/pymagicc/pull/224>`_) Add ``INVERSEEMIS.OUT`` reader

--- a/pymagicc/definitions/__init__.py
+++ b/pymagicc/definitions/__init__.py
@@ -340,8 +340,8 @@ def get_magicc7_to_openscm_variable_mapping(inverse=False):
             "CH4OXSTRATH2O_RF": "Radiative Forcing|CH4 Oxidation Stratospheric H2O",  # what is this
             "LANDUSE_RF": "Radiative Forcing|Land-use Change",
             "BCSNOW_RF": "Radiative Forcing|Black Carbon on Snow",
-            "CO2PF_EMIS": "Emissions|CO2|MAGICC Permafrost",
-            "CH4PF_EMIS": "Emissions|CH4|MAGICC Permafrost",
+            "CO2PF_EMIS": "Land to Air Flux|CO2|MAGICC Permafrost",
+            # "CH4PF_EMIS": "Land to Air Flux|CH4|MAGICC Permafrost",
         }
     )
 

--- a/pymagicc/definitions/__init__.py
+++ b/pymagicc/definitions/__init__.py
@@ -341,7 +341,7 @@ def get_magicc7_to_openscm_variable_mapping(inverse=False):
             "LANDUSE_RF": "Radiative Forcing|Land-use Change",
             "BCSNOW_RF": "Radiative Forcing|Black Carbon on Snow",
             "CO2PF_EMIS": "Land to Air Flux|CO2|MAGICC Permafrost",
-            # "CH4PF_EMIS": "Land to Air Flux|CH4|MAGICC Permafrost",
+            # "CH4PF_EMIS": "Land to Air Flux|CH4|MAGICC Permafrost",  # TODO: test and then add when needed
         }
     )
 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -71,7 +71,7 @@ def test_convert_magicc7_to_magicc6_variables(magicc7, magicc6):
         ("CH4_CONC", "Atmospheric Concentrations|CH4"),
         ("EXTRA_RF", "Radiative Forcing|Extra"),
         ("CCL4_INVERSE_EMIS", "Inverse Emissions|CCl4"),
-        ("CO2PF_EMIS", "Emissions|CO2|MAGICC Permafrost"),
+        ("CO2PF_EMIS", "Land to Air Flux|CO2|MAGICC Permafrost"),
         ("SURFACE_TEMP", "Surface Temperature"),
     ],
 )
@@ -89,7 +89,7 @@ def test_convert_magicc7_to_openscm_variables(magicc7, openscm):
         ("CH4_EMIS", "Emissions|CH4"),
         ("CH3CCL3_EMIS", "Emissions|CH3CCl3"),
         ("CCL4_INVERSE_EMIS", "Inverse Emissions|CCl4"),
-        ("CO2PF_EMIS", "Emissions|CO2|MAGICC Permafrost"),
+        ("CO2PF_EMIS", "Land to Air Flux|CO2|MAGICC Permafrost"),
         ("SURFACE_TEMP", "Surface Temperature"),
     ],
 )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2262,7 +2262,7 @@ def test_load_out_co2pf_emis():
     assert "__MAGICC 6.X DATA OUTPUT FILE__" in mdata.metadata["header"]
     assert (mdata["todo"] == "N/A").all()
     assert (mdata["unit"] == "Gt C / yr").all()
-    assert (mdata["variable"] == "Emissions|CO2|MAGICC Permafrost").all()
+    assert (mdata["variable"] == "Air to Land Flux|CO2|MAGICC Permafrost").all()
 
     assert_mdata_value(mdata, 0, region="World", year=1765)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2262,7 +2262,7 @@ def test_load_out_co2pf_emis():
     assert "__MAGICC 6.X DATA OUTPUT FILE__" in mdata.metadata["header"]
     assert (mdata["todo"] == "N/A").all()
     assert (mdata["unit"] == "Gt C / yr").all()
-    assert (mdata["variable"] == "Air to Land Flux|CO2|MAGICC Permafrost").all()
+    assert (mdata["variable"] == "Land to Air Flux|CO2|MAGICC Permafrost").all()
 
     assert_mdata_value(mdata, 0, region="World", year=1765)
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable) (N/A)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) (N/A)
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <http://link-to-pr.com>`_) Added feature which does something
- (`#XX <http://link-to-pr.com>`_) Fixed bug identified in (`#XX <http://link-to-issue.com>`_)
```

This changes the way permafrost emissions are named. Putting them under emissions is problematic as emissions are implicitly anthropogenic. If you have "Emissions|CO2|Permafrost" then when you add up all sub-categories of CO2 you end up with non-anthropogenic emissions in there too which isn't what you want. This renaming should avoid that sort of thing happening and allows Emissions to remain being implicitly anthropogenic (unfortunately we shouldn't make it explicit as then things will explode in terms of mapping to pyam variables where emissions are always anthropogenic).