### PR TITLE
Override magicc7 user config with sane defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#239 <https://github.com/openclimatedata/pymagicc/pull/239>`_) Explicitly overwrite tuning model and emission scenario parameters for MAGICC7 when a temporary copy is created
 - (`#229 <https://github.com/openclimatedata/pymagicc/pull/229>`_) Add more robust tests of io, in particular that column order and spacing in files is preserved
 - (`#233 <https://github.com/openclimatedata/pymagicc/pull/233>`_) Fix inplace append hard coding as identified in `#232 <https://github.com/openclimatedata/pymagicc/issues/232>`_
 - (`#234 <https://github.com/openclimatedata/pymagicc/pull/234>`_) Raise ``ValueError`` if ``only`` doesn't match an output variable in ``MAGICC.run`` (solves `#231 <https://github.com/openclimatedata/pymagicc/issues/231>`_)

--- a/pymagicc/core.py
+++ b/pymagicc/core.py
@@ -930,3 +930,27 @@ class MAGICC6(MAGICCBase):
 
 class MAGICC7(MAGICCBase):
     version = 7
+
+    def create_copy(self):
+        super(MAGICC7, self).create_copy()
+        # Override the USER configuration for MAGICC7 so that it always conforms with pymagicc's expectations
+        # The MAGCFG_USER.CFG configuration for MAGICC7 changes frequently in the repository
+        self.update_config('MAGCFG_USER.CFG', **{
+            'file_emisscen_2': "NONE",
+            'file_emisscen_3': "NONE",
+            'file_emisscen_4': "NONE",
+            'file_emisscen_5': "NONE",
+            'file_emisscen_6': "NONE",
+            'file_emisscen_7': "NONE",
+            'file_emisscen_8': "NONE",
+            'file_tuningmodel_1': "PYMAGICC",
+            'file_tuningmodel_2': "USER",
+            'file_tuningmodel_3': "USER",
+            'file_tuningmodel_4': "USER",
+            'file_tuningmodel_5': "USER",
+            'file_tuningmodel_6': "USER",
+            'file_tuningmodel_7': "USER",
+            'file_tuningmodel_8': "USER",
+            'file_tuningmodel_9': "USER",
+            'file_tuningmodel_10': "USER"
+        })

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,7 +16,7 @@ import f90nml
 
 from pymagicc import MAGICC6, MAGICC7, rcp26, zero_emissions
 from pymagicc.core import MAGICCBase, config, _clean_value
-from pymagicc.io import MAGICCData
+from pymagicc.io import MAGICCData, read_cfg_file
 from .test_config import config_override  #  noqa
 from .conftest import MAGICC6_DIR, TEST_DATA_DIR
 
@@ -1095,3 +1095,31 @@ def test_get_output_filenames(mock_listdir):
         ]
     )
     np.testing.assert_array_equal(obs, exp)
+
+
+def test_default_config(package):
+    if package.version == 6:
+        pytest.skip('Only checking MAGICC7')
+
+    expected_config = {
+        'file_emisscen_2': "NONE",
+        'file_emisscen_3': "NONE",
+        'file_emisscen_4': "NONE",
+        'file_emisscen_5': "NONE",
+        'file_emisscen_6': "NONE",
+        'file_emisscen_7': "NONE",
+        'file_emisscen_8': "NONE",
+        'file_tuningmodel_1': "PYMAGICC",
+        'file_tuningmodel_2': "USER",
+        'file_tuningmodel_3': "USER",
+        'file_tuningmodel_4': "USER",
+        'file_tuningmodel_5': "USER",
+        'file_tuningmodel_6': "USER",
+        'file_tuningmodel_7': "USER",
+        'file_tuningmodel_8': "USER",
+        'file_tuningmodel_9': "USER",
+        'file_tuningmodel_10': "USER"
+    }
+    cfg = read_cfg_file(join(package.run_dir, 'MAGCFG_USER.CFG'))
+    for key, expected in expected_config.items():
+        assert cfg['nml_allcfgs'][key] == expected


### PR DESCRIPTION
# Pull request

The MAGCFG_USER.CFG file in the magicc repository is in a constant state of flux. It would be nice to overwrite the MAGICC7 config in pymagicc rather than duplicating this everywhere

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Description in ``CHANGELOG.rst`` added
