### PR TITLE
Allow out_dynamic_vars parameter to be used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#250 <https://github.com/openclimatedata/pymagicc/pull/253>`_) Add support for ``out_dynamic_vars`` parameter
 - (`#250 <https://github.com/openclimatedata/pymagicc/pull/250>`_) Add support for ``.MAG`` files
 - (`#249 <https://github.com/openclimatedata/pymagicc/pull/249>`_) Update to keep pace with MAGICC7 development
 - (`#247 <https://github.com/openclimatedata/pymagicc/pull/247>`_) Upgrade pyam dependency to use nominated release

--- a/pymagicc/core.py
+++ b/pymagicc/core.py
@@ -777,7 +777,9 @@ class MAGICCBase(object):
 
     def _convert_out_config_flags_to_integers(self, config_dict):
         for key, value in config_dict.items():
-            if key.startswith("out") and key != "out_ascii_binary":
+            # Ignore all out_x_vars variables as that should be a list of strings
+            # Note that there is a variable OUT_ALLOWANYDYNAMICVARS which should be in integer
+            if key.startswith("out") and key != "out_ascii_binary" and not key.endswith('_vars'):
                 config_dict[key] = 1 if value else 0
 
         return config_dict

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-from os import remove, environ
+from os import remove, listdir
 from os.path import exists, join
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -1183,3 +1183,33 @@ def test_out_forcing():
         res.filter(variable="*Conc*CO2", year=1876, region="World").values.squeeze()
         == 289.2
     )
+
+
+def test_format_config():
+    inp = {
+        "out_temperature": True,
+        "out_allowdynamicvars": False,
+        "out_keydata1_vars": ["DAT_SURF_TEMP"],
+        "out_dynamic_vars": ["DAT_SURF_TEMP"]
+    }
+    exp = {
+        "out_temperature": 1,
+        "out_allowdynamicvars": 0,
+        "out_keydata1_vars": ["DAT_SURF_TEMP"],
+        "out_dynamic_vars": ["DAT_SURF_TEMP"]
+    }
+    m = MAGICC7()
+
+    res = m._convert_out_config_flags_to_integers(inp)
+    assert exp == res
+
+
+@pytest.mark.slow
+def test_limit_output():
+    # Check that we can run the model an only output a single variable
+    with MAGICC7() as m:
+        m.set_output_variables(write_binary=True, write_ascii=False)
+        res = m.run(out_dynamic_vars=['DAT_SURFACE_TEMP'])
+
+        assert listdir(m.out_dir) == ['DAT_SURFACE_TEMP.BINOUT']
+        assert res['variable'].unique() == ['Surface Temperature']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1207,9 +1207,12 @@ def test_format_config():
 @pytest.mark.slow
 def test_limit_output():
     # Check that we can run the model an only output a single variable
-    with MAGICC7() as m:
-        m.set_output_variables(write_binary=True, write_ascii=False)
-        res = m.run(out_dynamic_vars=['DAT_SURFACE_TEMP'])
+    try:
+        with MAGICC7() as m:
+            m.set_output_variables(write_binary=True, write_ascii=False)
+            res = m.run(out_dynamic_vars=['DAT_SURFACE_TEMP'])
 
-        assert listdir(m.out_dir) == ['DAT_SURFACE_TEMP.BINOUT']
-        assert res['variable'].unique() == ['Surface Temperature']
+            assert listdir(m.out_dir) == ['DAT_SURFACE_TEMP.BINOUT']
+            assert res['variable'].unique() == ['Surface Temperature']
+    except FileNotFoundError:
+        pytest.skip('MAGICC7 not installed')


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Description in ``CHANGELOG.rst`` added

Doesn't convert out_dynamic_vars to an integer